### PR TITLE
Separate the damage label to its own class

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://scripts/interaction/container_obj.gd"
 }, {
+"base": "Label",
+"class": "DamageLabel",
+"language": "GDScript",
+"path": "res://scripts/entity/damage_label.gd"
+}, {
 "base": "KinematicBody2D",
 "class": "DamageableEntity",
 "language": "GDScript",
@@ -63,6 +68,7 @@ _global_script_class_icons={
 "BasicEnemy": "",
 "BasicEntity": "",
 "ContainerObject": "",
+"DamageLabel": "",
 "DamageableEntity": "",
 "InteractableEntity": "",
 "InteractionObject": "",

--- a/scripts/entity/damage_label.gd
+++ b/scripts/entity/damage_label.gd
@@ -1,0 +1,31 @@
+extends Label
+
+class_name DamageLabel
+
+var color setget color_set, color_get
+var texture: Texture = null
+
+const max_count: float = 30.0
+var count: float = max_count
+
+func color_set(new_value):
+	color = new_value
+	set("custom_colors/font_color", Color(color.r, color.g, color.b, 1))
+
+func color_get():
+	return color
+
+func _ready():
+	color_set(Color(1, 0, 0))
+
+func _physics_process(_delta):
+	if count == 0:
+		queue_free()
+	elif count <= 10:
+		set("custom_colors/font_color", Color(color.r, color.g, color.b, count/10))
+	elif (texture == null):
+		rect_position = Vector2(-5, count - max_count)
+	else:
+		rect_position = Vector2(-5, -texture.get_width()/2.0 + count - max_count)
+	
+	count -= 1

--- a/scripts/entity/damageable.gd
+++ b/scripts/entity/damageable.gd
@@ -19,46 +19,29 @@ export(int) var regen_rate = 1
 
 #Internal globals
 var hp
-var dmg_label
-var dmg_label_timer
 
 func _ready():
 	type = "damageable"
 	hp = max_hp #TODO: save system handling
 	texture = tx
-	
-	#Damage label
-	var damage_label_timer = Timer.new()
-	damage_label_timer.wait_time = 2
-	damage_label_timer.one_shot = true
-	add_child(damage_label_timer)
-	damage_label_timer.connect("timeout", self, "hide_label")
-	dmg_label_timer = damage_label_timer
-	var damage_label = Label.new()
-	damage_label.rect_position = Vector2(-5, -20)
-	damage_label.name = "damage_label"
-	damage_label.set("custom_colors/font_color", Color.red)
-	dmg_label = damage_label
-	dmg_label.hide()
-	add_child(damage_label)
-	
+
 	#Health regen
 	if regen_enabled:
 		pass #TODO
 
 func hurt(damage):
-	dmg_label.text = str(damage)
-	dmg_label.show()
-	dmg_label_timer.start()
+	var damage_label = DamageLabel.new()
+	add_child(damage_label)
+	damage_label.text = str(damage)
+	damage_label.color_set(Color(1, 0, 0)) #TODO: update color based on type of damage, etc.
+	damage_label.show()
+
 	if max_hp == -1: return
 	hp -= damage
 
 func _process(_delta):
 	if hp <= 0 && max_hp != -1:
 		emit_signal("dead")
-
-func hide_label():
-	dmg_label.hide()
 
 func regen():
 	if max_hp == -1: return

--- a/scripts/player/player.gd
+++ b/scripts/player/player.gd
@@ -3,12 +3,12 @@ extends "res://scripts/entity/damageable.gd"
 class_name Player
 
 export(int) var speed = 100
-var vel  = Vector2()
+var velocity  = Vector2()
 
-puppet var pvel = Vector2()
-puppet var ppos = Vector2()
+puppet var prevVelocity = Vector2()
+puppet var prevPos = Vector2()
 
-func _ready():
+func _ready():	
 	type = "player"
 	if !gstate.is_multiplayer:
 		$Camera2D.current = true
@@ -21,7 +21,7 @@ func _ready():
 	else:
 		$Label.text = gstate.players[pid].uname
 	
-	ppos = position
+	prevPos = position
 
 var down
 
@@ -42,21 +42,21 @@ func _process(_delta):
 		mdir.x = Input.get_action_strength("ui_right") - Input.get_action_strength("ui_left")
 		mdir.y = Input.get_action_strength("ui_down") - Input.get_action_strength("ui_up")
 		
-		vel = mdir.normalized() * speed
+		velocity = mdir.normalized() * speed
 		
 		if gstate.is_multiplayer:
-			rset_unreliable("pvel", vel)
-			rset_unreliable("ppos", position)
+			rset_unreliable("prevVelocity", velocity)
+			rset_unreliable("prevPos", position)
 	elif gstate.is_multiplayer:
-		vel = pvel
+		velocity = prevVelocity
 		if !gstate.is_paused: # Prevent the player from jumping back to (0,0)
-			position = ppos
+			position = prevPos
 	
 	if !gstate.is_paused:
-		vel = move_and_slide(vel)
+		velocity = move_and_slide(velocity)
 	
 	#TODO: break this out in network system
 	$RayCast2D.look_at(get_global_mouse_position())
 	
 	if gstate.is_multiplayer and !is_network_master():
-		ppos = position
+		prevPos = position


### PR DESCRIPTION
Allows multiple damage labels to be spawned at once by the same damageable entity (previously not possible). Also makes it reusable anywhere else it might need to be. The class takes color and texture arguments, using texture for horizontal offset if provided. Color defaults to red if not set, and is useful for elemental damage and that sort of thing.